### PR TITLE
Fix wifi-setup fails when psk contains spaces

### DIFF
--- a/usr/bin/wifi-setup
+++ b/usr/bin/wifi-setup
@@ -17,5 +17,5 @@ fi
 
 nmcli c add con-name $SSID ifname wlan0 type wifi ssid $SSID
 nmcli c modify $SSID wifi-sec.key-mgmt wpa-psk
-nmcli c modify $SSID wifi-sec.psk $PSWD
+nmcli c modify $SSID wifi-sec.psk "$PSWD"
 nmcli c up $SSID


### PR DESCRIPTION
Given a wifi password such as `this is my psk`, prior to this
change `wifi-setup` sent the command:

    nmcli c modify MYSSID wifi-sec.psk this is my psk

which would fail with a complaint about `this` not being a valid psk.